### PR TITLE
Add support for more algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.4] - 2024-09-01
+
+### Added
+- Added support for HS256, HS384, HS512, PS256, PS384, PS512, and EdDSA
+
+### Deprecated
+- Deprecate `generateJWKPair` (use `generateJWK` instead... It's no longer always a key pair)
+
 ## [v1.0.3] - 2024-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,15 +40,32 @@ and [JWT](https://jwt.io/) support via the [`crypto` API](https://developer.mozi
 
 ### Supported Algorithms
 - RS256
+- RS384
+- RS512
 - ES256
+- ES384
+- ES512
+- HS256
+- HS384
+- HS512
+- PS256
+- PS384
+- PS512
+- EdDSA
+
+> [!Note]
+> EdDSA is currently experimental in Node.js and is only suported in Safari. See [Browser Compatibility on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign#browser_compatibility).
+
+## Not Supported
+- ES256K
 
 ### Example
 
 ```js
-import { generateJWKPair, createJWT, verifyJWT } from '@shgysk8zer0/jwt-jwk';
+import { generateJWK, createJWT, verifyJWT } from '@shgysk8zer0/jwt-jwk';
 
 // Generate a JWK pair
-const { publicKey, privateKey } = await generateJWKPair();
+const { publicKey, privateKey } = await generateJWK();
 
 // Create a JWT
 const token = await createJWT({ data: 'some payload' }, privateKey);
@@ -59,5 +76,5 @@ const verifiedPayload = await verifyJWT(token, publicKey);
 
 ## Limitations
 
-Due to using JWKs and public/private keys, this currently does not support HS256
-or any symmetric keys.
+Due to using JWKs and public/private keys, this currently does not support algorithms
+not suppported by `crypto.subtle`.

--- a/consts.js
+++ b/consts.js
@@ -8,7 +8,20 @@ export const ES512 = 'ES512';
 export const RS256 = 'RS256';
 export const RS384 = 'RS384';
 export const RS512 = 'RS512';
+export const HS256 = 'HS256';
+export const HS384 = 'HS384';
+export const HS512 = 'HS512';
+export const PS256 = 'PS256';
+export const PS384 = 'PS384';
+export const PS512 = 'PS512';
+export const EdDSA = 'EdDSA';
 export const DEFAULT_ALGO = ES256;
+
+export const SHA256 = 'SHA-256';
+export const SHA384 = 'SHA-384';
+export const SHA512 = 'SHA-512';
+
+export const PUBLIC_EXPONENT = new Uint8Array([1, 0, 1]);
 
 /**
  * A mapping of algorithm names to their corresponding cryptographic parameters.
@@ -20,49 +33,83 @@ export const DEFAULT_ALGO = ES256;
  * @property {Object} RS256 - Configuration for the RSA Signature Algorithm (RSASSA-PKCS1-v1_5) using SHA-256 hash, a modulus length of 2048 bits, and a public exponent of 0x010001.
  * @property {Object} RS384 - Configuration for the RSA Signature Algorithm (RSASSA-PKCS1-v1_5) using SHA-384 hash, a modulus length of 3072 bits, and a public exponent of 0x010001.
  * @property {Object} RS512 - Configuration for the RSA Signature Algorithm (RSASSA-PKCS1-v1_5) using SHA-512 hash, a modulus length of 4096 bits, and a public exponent of 0x010001.
+ * @property {Object} HS256 - Configuration for the HMAC algorithm using SHA-256 hash.
+ * @property {Object} HS384 - Configuration for the HMAC algorithm using SHA-384 hash.
+ * @property {Object} HS512 - Configuration for the HMAC algorithm using SHA-512 hash.
+ * @property {Object} PS256 - Configuration for the RSA Signature Algorithm (RSA-PSS) using SHA-256 hash, a salt length of 32 bytes, a modulus length of 2048 bits, and a public exponent of 0x010001.
+ * @property {Object} PS384 - Configuration for the RSA Signature Algorithm (RSA-PSS) using SHA-384 hash, a salt length of 32 bytes, a modulus length of 3072 bits, and a public exponent of 0x010001.
+ * @property {Object} PS512 - Configuration for the RSA Signature Algorithm (RSA-PSS) using SHA-512 hash, a salt length of 32 bytes, a modulus length of 4096 bits, and a public exponent of 0x010001.
+ * @property {Object} EdDSA - Configuration for the Edwards-Curve Digital Signature Algorithm (EdDSA) using the Ed25519 curve.
  */
 export const ALGOS = {
 	ES256: {
 		name: 'ECDSA',
 		namedCurve: 'P-256',
-		hash: 'SHA-256',
+		hash: SHA256,
 	},
 	ES384: {
 		name: 'ECDSA',
 		namedCurve: 'P-384',
-		hash: 'SHA-384',
+		hash: SHA384,
 	},
 	ES512: {
 		name: 'ECDSA',
 		namedCurve: 'P-521',
-		hash: 'SHA-512',
+		hash: SHA512,
 	},
 	RS256: {
 		name: 'RSASSA-PKCS1-v1_5',
-		hash: 'SHA-256',
+		hash: SHA256,
 		modulusLength: 2048,
-		publicExponent: new Uint8Array([1, 0, 1]),
+		publicExponent: PUBLIC_EXPONENT,
 	},
 	RS384: {
 		name: 'RSASSA-PKCS1-v1_5',
-		hash: 'SHA-384',
+		hash: SHA384,
 		modulusLength: 3072,
-		publicExponent: new Uint8Array([1, 0, 1]),
+		publicExponent: PUBLIC_EXPONENT,
 	},
 	RS512: {
 		name: 'RSASSA-PKCS1-v1_5',
-		hash: 'SHA-512',
+		hash: SHA512,
 		modulusLength: 4096,
-		publicExponent: new Uint8Array([1, 0, 1]),
+		publicExponent: PUBLIC_EXPONENT,
 	},
-	// PS256: {
-	// 	name: 'RSASSA-PSS',
-	// 	hash: 'SHA-256',
-	// 	saltLength: 32, // Optional, but recommended
-	// 	maskLength: 32, // Optional, but recommended
-	// },
-	// HS256: {
-	// 	name: 'HMAC',
-	// 	hash: 'SHA-256',
-	// },
+	HS256: {
+		name: 'HMAC',
+		hash: SHA256,
+	},
+	HS384: {
+		name: 'HMAC',
+		hash: SHA384,
+	},
+	HS512: {
+		name: 'HMAC',
+		hash: SHA512,
+	},
+	PS256: {
+		name: 'RSA-PSS',
+		hash: SHA256,
+		saltLength: 32,
+		modulusLength: 2048,
+		publicExponent: PUBLIC_EXPONENT,
+	},
+	PS384: {
+		name: 'RSA-PSS',
+		hash: SHA384,
+		saltLength: 32,
+		modulusLength: 3072,
+		publicExponent: PUBLIC_EXPONENT,
+	},
+	PS512: {
+		name: 'RSA-PSS',
+		hash: SHA512,
+		saltLength: 32,
+		modulusLength: 4096,
+		publicExponent: PUBLIC_EXPONENT,
+	},
+	EdDSA: {
+		name: 'Ed25519',
+		namedCurve: 'Ed25519',
+	},
 };

--- a/jwk.js
+++ b/jwk.js
@@ -11,6 +11,18 @@ import { findKeyAlgo } from './utils.js';
  * @throws {Error} - If there's an error generating the JWK pair.
  */
 export async function generateJWKPair(algo = DEFAULT_ALGO) {
+	console.warn('`generateJWKPair` is deprecated. Please use `generateJWK` instead.');
+	return await generateJWK(algo);
+}
+
+/**
+ * Generates a new JSON Web Key (JWK) pair or secret key (single) with the specified algorithm.
+ *
+ * @param {string} algo - The algorithm to use for the JWK pair. Defaults to `"ES256"`.
+ * @returns {Promise<CryptoKeyPair | CryptoKey>} A promise that resolves to the generated JWK pair.
+ * @throws {Error} - If there's an error generating the JWK pair.
+ */
+export async function generateJWK(algo = DEFAULT_ALGO) {
 	return await crypto.subtle.generateKey(
 		ALGOS[algo],
 		true,
@@ -44,7 +56,7 @@ export async function createJWKFile(key, name) {
 	if (typeof name === 'string' && name.length !== 0) {
 		return new File([JSON.stringify(extracted)], name, { type: MIME_TYPE });
 	} else {
-		return new File([JSON.stringify(extracted)], `${key.type}.jwk`, { type: MIME_TYPE});
+		return new File([JSON.stringify(extracted)], `${key.algorithm.name}-${key.type}.jwk`, { type: MIME_TYPE});
 	}
 }
 

--- a/jwt.js
+++ b/jwt.js
@@ -4,6 +4,7 @@ import { findKeyAlgo, getKeyId } from './utils.js';
 /**
  * Generates a JSON Web Token (JWT) using the provided payload and private key.
  *
+ * @deprecated
  * @param {Object} payload - The payload data to include in the JWT.
  * @param {CryptoKey} privateKey - The private key used to sign the JWT.
  * @returns {Promise<string>} A promise that resolves to the generated JWT.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/jwk-utils",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/jwk-utils",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/jwk-utils",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Use JWK and JWTs using the Crypto API",
   "keywords": [
     "jwk",

--- a/tests.js
+++ b/tests.js
@@ -1,7 +1,10 @@
-import { generateJWKPair, createOriginAuthToken, decodeOriginToken, ALGOS } from './jwk-utils.js';
+import { generateJWK, createOriginAuthToken, decodeOriginToken, ALGOS } from './jwk-utils.js';
+
+const start = performance.now();
 
 const results = await Promise.allSettled(Object.keys(ALGOS).map(async alg => {
-	const { publicKey, privateKey } = await generateJWKPair(alg);
+	const keys = await generateJWK(alg);
+	const { publicKey, privateKey } = keys instanceof CryptoKey ? { publicKey: keys, privateKey: keys } : keys;
 	const token = await createOriginAuthToken('https://example.com', privateKey);
 	const decoded = await decodeOriginToken(token, 'https://example.com', publicKey);
 
@@ -10,10 +13,11 @@ const results = await Promise.allSettled(Object.keys(ALGOS).map(async alg => {
 	} else if (await decodeOriginToken('njkdfnfgkjfd', publicKey) !== null) {
 		throw new Error('Decoding invalid tokens should return `null`.');
 	}
-
 }));
 
 const errs = results.filter(result => result.status === 'rejected');
+
+console.info(`Test completed in ${performance.now() - start}ms.`);
 
 if (errs.length === 1) {
 	throw errs[0].reason;


### PR DESCRIPTION
### Added
- Added support for HS256, HS384, HS512, PS256, PS384, PS512, and EdDSA

### Deprecated
- Deprecate `generateJWKPair` (use `generateJWK` instead... It's no longer always a key pair)

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
