### PR TITLE
Add support for `CryptoKeyPair` in JWT creating/verifying functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.6] - 2024-09-02
+
+### Added
+- Create `.map` files for generated `.min.js` modules
+
+### Changed
+- JWT generating and verifying functions can now take either a `CryptoKey` or `CryptoKeyPair`
+
+### Fixed
+- Fixed bad `payload.exp` check
+
 ## [v1.0.5] - 2024-09-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Create `.map` files for generated `.min.js` modules
+- Add `verifyHeader` and `verifyPayload` for verifying decoded JWTs
 
 ### Changed
 - JWT generating and verifying functions can now take either a `CryptoKey` or `CryptoKeyPair`

--- a/consts.js
+++ b/consts.js
@@ -39,7 +39,7 @@ export const PUBLIC_EXPONENT = new Uint8Array([1, 0, 1]);
  * @property {Object} PS256 - Configuration for the RSA Signature Algorithm (RSA-PSS) using SHA-256 hash, a salt length of 32 bytes, a modulus length of 2048 bits, and a public exponent of 0x010001.
  * @property {Object} PS384 - Configuration for the RSA Signature Algorithm (RSA-PSS) using SHA-384 hash, a salt length of 32 bytes, a modulus length of 3072 bits, and a public exponent of 0x010001.
  * @property {Object} PS512 - Configuration for the RSA Signature Algorithm (RSA-PSS) using SHA-512 hash, a salt length of 32 bytes, a modulus length of 4096 bits, and a public exponent of 0x010001.
- * @property {Object} EdDSA - Configuration for the Edwards-Curve Digital Signature Algorithm (EdDSA) using the Ed25519 curve.
+ * @property {Object} EdDSA - Configuration for the Edwards-Curve Digital Signature Algorithm (EdDSA) using the Ed25519 curve. Limited support.
  */
 export const ALGOS = {
 	ES256: {

--- a/firebase.js
+++ b/firebase.js
@@ -1,71 +1,101 @@
 import { ALGOS } from './consts.js';
-import { decodeRequestToken } from './jwt.js';
+import { decodeRequestToken, decodeToken } from './jwt.js';
 
 /**
  * Fetches a JSON Web Key (JWK) from Google Firebase for the given key ID (kid).
  *
- * @param {string} kid - The key ID of the JWK to fetch.
- * @returns {Promise<CryptoKey | null>} A promise that resolves to the imported JWK if found, or null if not found.
- * @throws {Error} - If there's an error fetching or importing the JWK.
-*/
+ * This function retrieves the JWK set from the Google Firebase metadata endpoint, locates the key with the specified `kid`, and imports it using the Web Crypto API.
+ *
+ * @param {string} kid - The key ID (kid) of the JWK to fetch.
+ * @property {boolean} [extractable=false] - Whether the imported key is extractable. Defaults to false.
+ * @property {FetchInit | object} [fetchInit] - (Optional) An object containing options to pass directly to the `fetch` function.
+ *
+ * @returns {Promise<CryptoKey | null>}
+ *  - Resolves to the imported JWK object if the key with the specified `kid` is found.
+ *  - Resolves to `null` if the key is not found.
+ *  - Rejects with an `Error` if there's an error fetching, parsing, or importing the JWK.
+ */
+export async function getFirebaseJWK(kid, extractable = false, fetchInit = {}) {
+	try {
+		const resp = await fetch('https://www.googleapis.com/robot/v1/metadata/jwk/securetoken@system.gserviceaccount.com', {
+			headers: { Accept: 'application/json' },
+			...fetchInit,
+		});
 
-export async function getFirebaseJWK(kid) {
-	const resp = await fetch('https://www.googleapis.com/robot/v1/metadata/jwk/securetoken@system.gserviceaccount.com', {
-		headers: { Accept: 'application/json' },
-		referrerPolicy: 'no-referrer',
-		crossOrigin: 'anonymous',
-	});
+		const data = await resp.json() ?? [];
 
-	const data = await resp.json() ?? [];
+		const key = data.keys.find(key => key.kid === kid);
 
-	const key = data.keys.find(key => key.kid === kid);
-
-	if (typeof key === 'object') {
-		return await crypto.subtle.importKey(
-			'jwk',
-			key,
-			ALGOS[key.alg],
-			false,
-			['verify'],
-		);
-	} else {
+		if (typeof key === 'object') {
+			return await crypto.subtle.importKey(
+				'jwk',
+				key,
+				ALGOS[key.alg],
+				extractable,
+				['verify'],
+			);
+		} else {
+			return null;
+		}
+	} catch {
 		return null;
 	}
 }
 
+/**
+ * Fetches a JSON Web Key (JWK) from Google Firebase for the given key ID (kid).
+ *
+ * @param {string} token - The Firebase ID token for a user.
+ * @param {FetchInit} fetchInit - (Optional) An object containing options for the fetch request.
+ * @returns {Promise<object | null>} A promise that resolves to the validated payload object.
+ */
+export async function verifyFirebaseIdToken(token, fetchInit = {}) {
+	const { header, payload, signature, data } = decodeToken(token);
+
+	if (typeof payload !== 'object' || payload === null || typeof header !== 'object' || header === null) {
+		return null;
+	} else if (! ['name', 'auth_time', 'iss', 'user_id', 'iat', 'exp', 'email'].every(prop => prop in payload)) {
+		return null;
+	} else if (! payload.iss.startsWith('https://securetoken.google.com/')) {
+		return null;
+	} else if (! await crypto.subtle.verify(
+		ALGOS[header.alg],
+		await getFirebaseJWK(header.kid, false, fetchInit),
+		signature,
+		data,
+	)) {
+		return null;
+	} else {
+		return payload;
+	}
+}
 
 /**
  *  Decodes and validates a Firebase request token from the Authorization header.
  *
  * @param {Request} req - The HTTP request object.
- * @returns {Promise<Object>} A promise that resolves to the validated payload object.
+ * @returns {Promise<object | null>} A promise that resolves to the validated payload object.
  * @throws {TypeError} - If the provided object is not a Request object.
- * @throws {Error} - If the token is invalid (e.g., expired, malformed signature, unexpected payload content).
  */
-export async function decodeFirebaseAuthRequestToken(req) {
+export async function decodeFirebaseAuthRequestToken(req, fetchInit = {}) {
 	if (! (req instanceof Request)) {
 		throw new TypeError('Not a request object.');
 	} else {
-		const now = parseInt(Date.now() / 1000);
 		const { header, payload, signature, data } = decodeRequestToken(req);
 
-		if (typeof payload !== 'object') {
-			throw new TypeError('Invalid payload in token.');
-		} else if (! ['alg', 'kid'].every(prop => prop in header)) {
-			throw new Error('Invalid token header.');
+		if (typeof payload !== 'object' || payload === null || typeof header !== 'object' || header === null) {
+			return null;
 		} else if (! ['name', 'auth_time', 'iss', 'user_id', 'iat', 'exp', 'email'].every(prop => prop in payload)) {
-			throw new Error('Invalid token payload.');
-		} else if (payload.iat > now) {
-			throw new Error('Token cannot have been generated in future.');
-		} else if (payload.exp > now) {
-			throw new Error('Token is expired.');
-		} else if (!await crypto.subtle.verify(
+			return null;
+		} else if (! payload.iss.startsWith('https://securetoken.google.com/')) {
+			return null;
+		} else if (! await crypto.subtle.verify(
 			ALGOS[header.alg],
-			await getFirebaseJWK(header.kid),
+			await getFirebaseJWK(header.kid, false, fetchInit),
 			signature,
 			data,
 		)) {
-			throw new Error('Token signature did not validate.');
+			return null;
 		} else {
 			return payload;
 		}

--- a/firebase.js
+++ b/firebase.js
@@ -1,5 +1,5 @@
 import { ALGOS } from './consts.js';
-import { decodeRequestToken, decodeToken } from './jwt.js';
+import { decodeRequestToken, decodeToken, verifyHeader, verifyPayload } from './jwt.js';
 
 /**
  * Fetches a JSON Web Key (JWK) from Google Firebase for the given key ID (kid).
@@ -52,7 +52,7 @@ export async function getFirebaseJWK(kid, extractable = false, fetchInit = {}) {
 export async function verifyFirebaseIdToken(token, fetchInit = {}) {
 	const { header, payload, signature, data } = decodeToken(token);
 
-	if (typeof payload !== 'object' || payload === null || typeof header !== 'object' || header === null) {
+	if (! (verifyHeader(header) && verifyPayload(payload))) {
 		return null;
 	} else if (! ['name', 'auth_time', 'iss', 'user_id', 'iat', 'exp', 'email'].every(prop => prop in payload)) {
 		return null;
@@ -83,7 +83,7 @@ export async function decodeFirebaseAuthRequestToken(req, fetchInit = {}) {
 	} else {
 		const { header, payload, signature, data } = decodeRequestToken(req);
 
-		if (typeof payload !== 'object' || payload === null || typeof header !== 'object' || header === null) {
+		if (! (verifyHeader(header) && verifyPayload(payload))) {
 			return null;
 		} else if (! ['name', 'auth_time', 'iss', 'user_id', 'iat', 'exp', 'email'].every(prop => prop in payload)) {
 			return null;

--- a/origin-tokens.js
+++ b/origin-tokens.js
@@ -16,7 +16,6 @@ import { decodeRequestToken, createJWT, verifyJWT } from './jwt.js';
  */
 export async function createOriginAuthToken(origin, privateKey, {
 	ttl = 60,
-	leeway = 60,
 	id = crypto.getRandomValues(new Uint8Array(8)).toHex(),
 	issued = new Date(),
 } = {}) {
@@ -30,7 +29,7 @@ export async function createOriginAuthToken(origin, privateKey, {
 		return await createJWT({
 			iss: origin,
 			iat: issuedAt,
-			nbf: issuedAt - leeway,
+			nbf: issuedAt,
 			exp: issuedAt + ttl,
 			jti: id,
 		}, privateKey);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/jwk-utils",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/jwk-utils",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/jwk-utils",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Use JWK and JWTs using the Crypto API",
   "keywords": [
     "jwk",
@@ -44,7 +44,7 @@
     "lint:js": "eslint .",
     "fix:js": "eslint . --fix",
     "build": "npm run build:js",
-    "clean": "rm -f ./*.cjs",
+    "clean": "rm -f ./*.cjs *.min.js *.map",
     "build:js": "npm run clean && rollup -c rollup.config.js",
     "run:tests": "node tests.js",
     "create:lock": "npm i --package-lock-only --ignore-scripts --no-audit --no-fund",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,5 +27,6 @@ export default modules.map(module => ({
 		file: `${module}.min.js`,
 		format: 'esm',
 		plugins: outputPlugins,
+		sourcemap: 'external',
 	}]
 }));

--- a/tests.js
+++ b/tests.js
@@ -1,23 +1,22 @@
-import { generateJWK, createOriginAuthToken, decodeOriginToken, ALGOS } from './jwk-utils.js';
+import { generateJWK, createOriginAuthToken, verifyJWT, ALGOS } from './jwk-utils.js';
 
-const start = performance.now();
+console.time('Running tests');
 
 const results = await Promise.allSettled(Object.keys(ALGOS).map(async alg => {
 	const keys = await generateJWK(alg);
-	const { publicKey, privateKey } = keys instanceof CryptoKey ? { publicKey: keys, privateKey: keys } : keys;
-	const token = await createOriginAuthToken('https://example.com', privateKey);
-	const decoded = await decodeOriginToken(token, 'https://example.com', publicKey);
+	const token = await createOriginAuthToken('https://example.com', keys);
+	const decoded = await verifyJWT(token, keys);
 
 	if (decoded === null) {
-		throw new Error('Error decoding token.');
-	} else if (await decodeOriginToken('njkdfnfgkjfd', publicKey) !== null) {
-		throw new Error('Decoding invalid tokens should return `null`.');
+		throw new Error(`Error decoding token: ${token}`);
+	} else {
+		return null;
 	}
 }));
 
 const errs = results.filter(result => result.status === 'rejected');
 
-console.info(`Test completed in ${performance.now() - start}ms.`);
+console.timeEnd('Running tests');
 
 if (errs.length === 1) {
 	throw errs[0].reason;


### PR DESCRIPTION
### Added
- Create `.map` files for generated `.min.js` modules
- Add `verifyHeader` and `verifyPayload` for verifying decoded JWTs

### Changed
- JWT generating and verifying functions can now take either a `CryptoKey` or `CryptoKeyPair`

### Fixed
- Fixed bad `payload.exp` check