### PR TITLE
Fix bug in re-importing polyfills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.12] - 2024-09-10
+
+### Removed
+- Do not load `@shgysk8zer0/polyfills` except in `main`/`module`/`jwk-utils` due to conflicts
+
 ## [v1.0.11] - 2024-09-10
 
 ### Added

--- a/jwk-utils.test.js
+++ b/jwk-utils.test.js
@@ -1,14 +1,14 @@
+import { generateJWK, createOriginAuthToken, ALGOS, verifyRequestToken, HS256, importJWK, exportJWK, verifyJWT } from './jwk-utils.js';
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { generateJWK, createOriginAuthToken, ALGOS, verifyRequestToken, HS256, importJWK, exportJWK, verifyJWT } from './jwk-utils.js';
-import events from 'node:events';
+import { setMaxListeners } from 'node:events';
 
 const invalidKey = await generateJWK(HS256);
 const signal = AbortSignal.timeout(60_000);
 const algs = Object.keys(ALGOS);
 
 // Do not warn about abort event listeners causing memory leaks.
-events.setMaxListeners(algs.length * 5, signal);
+setMaxListeners(algs.length * 5, signal);
 
 describe('JWK Utils Tests', async () => {
 	for (const alg of algs) {

--- a/jwk.js
+++ b/jwk.js
@@ -1,5 +1,3 @@
-import '@shgysk8zer0/polyfills';
-
 import { MIME_TYPE, DEFAULT_ALGO, ALGOS, HS256 } from './consts.js';
 import { findKeyAlgo } from './utils.js';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/jwk-utils",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/jwk-utils",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/jwk-utils",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Use JWK and JWTs using the Crypto API",
   "keywords": [
     "jwk",


### PR DESCRIPTION
Importing `@shgysk8zer0/polyfills` causes client-side issues due to duplication of trust policies. Only import it in main bundle/module.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
